### PR TITLE
Reexport the truetype crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,9 @@ this package.
 
 ```rust
 extern crate opentype;
-extern crate truetype;
 
 use opentype::Font;
-use truetype::{FontHeader, HorizontalHeader, NamingTable};
+use opentype::truetype::{FontHeader, HorizontalHeader, NamingTable};
 
 macro_rules! ok(($result:expr) => ($result.unwrap()));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,9 @@
 //!
 //! ```
 //! extern crate opentype;
-//! extern crate truetype;
 //!
 //! use opentype::Font;
-//! use truetype::{FontHeader, HorizontalHeader, NamingTable};
+//! use opentype::truetype::{FontHeader, HorizontalHeader, NamingTable};
 //!
 //! macro_rules! ok(($result:expr) => ($result.unwrap()));
 //!
@@ -35,10 +34,10 @@
 //! # }
 //! ```
 
-extern crate postscript;
+pub extern crate postscript;
 
 #[macro_use(flags)]
-extern crate truetype;
+pub extern crate truetype;
 
 #[macro_use]
 mod macros;


### PR DESCRIPTION
This allows users to access it without declaring their own dependency whose version requirement needs to be kept in sync with that of the opentype crate.